### PR TITLE
Fix invalid tag key in emoji.json

### DIFF
--- a/php/emoji.php
+++ b/php/emoji.php
@@ -74,7 +74,7 @@ function getTag($_string, $_url = true)
 		return null;
 	}
 	
-	return (':' . $result. ':');
+	return $result;
 }
 
 function output($_data, $_mime = null, $_exit = 0)


### PR DESCRIPTION
Fixed emoji selection for keys in emoji.index.json that do not contain ":".

The lookUpTag() function searches for tags using keys from emoji.index.json, where all keys are formatted without ":"